### PR TITLE
Update to latest nmigen master

### DIFF
--- a/gateware/daqnet/__init__.py
+++ b/gateware/daqnet/__init__.py
@@ -19,3 +19,7 @@ def main():
     frag = top.elaborate(plat)
     plat.build(frag, args.device, "build/", freq=100, emit_v=args.verilog,
                seed=args.seed)
+
+    ## Manually set this flag on the top object to prevent
+    ## erroneousness error message when python runtime is cleaned up
+    frag._Elaboratable__used = True

--- a/gateware/daqnet/ethernet/crc.py
+++ b/gateware/daqnet/ethernet/crc.py
@@ -5,10 +5,10 @@ Copyright 2018-2019 Adam Greig
 Released under the MIT license; see LICENSE for details.
 """
 
-from nmigen import Module, Signal, Memory
+from nmigen import Module, Signal, Memory, Elaboratable
 
 
-class CRC32:
+class CRC32(Elaboratable):
     """
     Ethernet CRC32
 

--- a/gateware/daqnet/ethernet/ip.py
+++ b/gateware/daqnet/ethernet/ip.py
@@ -8,10 +8,10 @@ Released under the MIT license; see LICENSE for details.
 import operator
 import functools
 from contextlib import contextmanager
-from nmigen import Module, Signal, Memory, Const
+from nmigen import Module, Signal, Memory, Const, Elaboratable
 
 
-class IPStack:
+class IPStack(Elaboratable):
     """
     IP stack.
 
@@ -161,7 +161,7 @@ class IPStack:
         return m
 
 
-class _StackLayer:
+class _StackLayer(Elaboratable):
     """
     Layer in IP stack.
 
@@ -835,7 +835,7 @@ class _UDPTxLayer(_StackLayer):
         return self.m
 
 
-class _InternetChecksum:
+class _InternetChecksum(Elaboratable):
     """
     Implements the Internet Checksum algorithm from RFC 1071.
 
@@ -1326,6 +1326,7 @@ def test_udp_rx():
 
     ipstack = IPStack(mac_addr, ip4_addr, udp_len, udp_port,
                       rx_mem_port, tx_mem_port, None, user_rx_mem_port)
+    ipstack._Elaboratable__used = True
 
     def testbench():
         yield

--- a/gateware/daqnet/ethernet/mac.py
+++ b/gateware/daqnet/ethernet/mac.py
@@ -5,7 +5,7 @@ Copyright 2018-2019 Adam Greig
 Released under the MIT license; see LICENSE for details.
 """
 
-from nmigen import Module, Signal, Const, Memory, ClockDomain, Cat
+from nmigen import Module, Signal, Const, Memory, ClockDomain, Cat, Elaboratable
 from nmigen.lib.fifo import AsyncFIFO
 from nmigen.hdl.xfrm import DomainRenamer
 from .mdio import MDIO
@@ -13,7 +13,7 @@ from .rmii import RMIIRx, RMIITx
 from ..utils import PulseStretch
 
 
-class MAC:
+class MAC(Elaboratable):
     """
     Ethernet RMII MAC.
 
@@ -146,15 +146,15 @@ class MAC:
         rdr = DomainRenamer({"read": "sync", "write": "rmii"})
         wdr = DomainRenamer({"write": "sync", "read": "rmii"})
         rr = DomainRenamer("rmii")
-        m.submodules.rx_fifo = rdr(rx_fifo.elaborate(platform).lower(platform))
-        m.submodules.tx_fifo = wdr(tx_fifo.elaborate(platform).lower(platform))
-        m.submodules.rmii_rx = rr(rmii_rx.elaborate(platform).lower(platform))
-        m.submodules.rmii_tx = rr(rmii_tx.elaborate(platform).lower(platform))
+        m.submodules.rx_fifo = rdr(rx_fifo.elaborate(platform))
+        m.submodules.tx_fifo = wdr(tx_fifo.elaborate(platform))
+        m.submodules.rmii_rx = rr(rmii_rx.elaborate(platform))
+        m.submodules.rmii_tx = rr(rmii_tx.elaborate(platform))
 
         return m
 
 
-class PHYManager:
+class PHYManager(Elaboratable):
     """
     Manage a PHY over MDIO.
 

--- a/gateware/daqnet/ethernet/mac_address_match.py
+++ b/gateware/daqnet/ethernet/mac_address_match.py
@@ -8,10 +8,10 @@ Released under the MIT license; see LICENSE for details.
 import operator
 from functools import reduce
 
-from nmigen import Module, Signal
+from nmigen import Module, Signal, Elaboratable
 
 
-class MACAddressMatch:
+class MACAddressMatch(Elaboratable):
     """
     MAC Address Matcher
 

--- a/gateware/daqnet/ethernet/mdio.py
+++ b/gateware/daqnet/ethernet/mdio.py
@@ -5,11 +5,11 @@ Copyright 2018-2019 Adam Greig
 Released under the MIT license; see LICENSE for details.
 """
 
-from nmigen import Module, Signal, Array
-from nmigen.lib.io import TSTriple
+from nmigen import Module, Signal, Array, Elaboratable
+from nmigen.compat.fhdl.specials import TSTriple
 
 
-class MDIO:
+class MDIO(Elaboratable):
     """
     MDIO interface controller.
 
@@ -59,7 +59,10 @@ class MDIO:
         # Create tristate for MDIO
         self.mdio_t = TSTriple()
         # Skip tristate creation when self.mdio=None (for use with simulator)
-        if self.mdio is not None:
+        # Manually set elaboratable flag to prevent build errors
+        if self.mdio is None:
+            self.mdio_t._Elaboratable__used = True
+        else:
             m.submodules += self.mdio_t.get_tristate(self.mdio)
 
         # Create divided clock for MDC

--- a/gateware/daqnet/ethernet/rmii.py
+++ b/gateware/daqnet/ethernet/rmii.py
@@ -5,12 +5,12 @@ Copyright 2018-2019 Adam Greig
 Released under the MIT license; see LICENSE for details.
 """
 
-from nmigen import Module, Signal, Cat
+from nmigen import Module, Signal, Cat, Elaboratable
 from .crc import CRC32
 from .mac_address_match import MACAddressMatch
 
 
-class RMIIRx:
+class RMIIRx(Elaboratable):
     """
     RMII receive module
 
@@ -99,7 +99,7 @@ class RMIIRx:
         return m
 
 
-class RMIIRxByte:
+class RMIIRxByte(Elaboratable):
     """
     RMII Receive Byte De-muxer
 
@@ -213,7 +213,7 @@ class RMIIRxByte:
         return m
 
 
-class RMIITx:
+class RMIITx(Elaboratable):
     """
     RMII transmit module
 
@@ -351,7 +351,7 @@ class RMIITx:
         return m
 
 
-class RMIITxByte:
+class RMIITxByte(Elaboratable):
     """
     RMII Transmit Byte Muxer
 

--- a/gateware/daqnet/platform.py
+++ b/gateware/daqnet/platform.py
@@ -340,9 +340,7 @@ class _Platform:
         io.d_out_0 = tstriple.o
         io.output_enable = tstriple.oe
         m.d.comb += tstriple.i.eq(io.d_in_0)
-        frag = m.lower(self)
-        frag.flatten = True
-        return frag
+        return m
 
 
 class SensorPlatform(_Platform):

--- a/gateware/daqnet/sd_adc.py
+++ b/gateware/daqnet/sd_adc.py
@@ -6,7 +6,8 @@ Released under the MIT license; see LICENSE for details.
 """
 
 import numpy as np
-from migen import Module, Signal, Instance, Constant, ClockDomain
+from nmigen import Module, Signal, Instance, ClockDomain
+from nmigen.hdl.ast import Const
 
 
 class SDADC(Module):
@@ -36,7 +37,7 @@ class SDADC(Module):
 
         self.specials += Instance(
             "SB_IO",
-            p_PIN_TYPE=Constant(0b00000, 6),
+            p_PIN_TYPE=Const(0b00000, 6),
             p_IO_STANDARD="SB_LVDS_INPUT",
             io_PACKAGE_PIN=inpin,
             o_D_IN_0=self.diff_in,
@@ -116,7 +117,7 @@ class CIC(Module):
 
 
 def test_cic():
-    from migen.sim import run_simulation
+    from nmigen.compat.sim import run_simulation
 
     # Generate 300us worth of samples of a sine wave, 150 samples
     sine = np.cos(2*np.pi*10e3*np.linspace(0, 200e-6, 150))

--- a/gateware/daqnet/uart.py
+++ b/gateware/daqnet/uart.py
@@ -5,7 +5,9 @@ Copyright 2017 Adam Greig
 Released under the MIT license; see LICENSE for details.
 """
 
-from migen import Module, Signal, If, FSM, NextValue, NextState, Array
+from nmigen import Module, Signal, Array
+from nmigen.compat.fhdl.structure import If
+from nmigen.compat.genlib.fsm import FSM, NextValue, NextState
 
 
 class UARTTx(Module):
@@ -167,7 +169,7 @@ class UARTTxFromMemory(Module):
 
 
 def test_uart_tx():
-    from migen.sim import run_simulation
+    from nmigen.compat.sim import run_simulation
     divider = 10
     data = Signal(8)
     start = Signal()
@@ -204,8 +206,8 @@ def test_uart_tx():
 
 
 def test_uart_tx_from_memory():
-    from migen.sim import run_simulation
-    from migen import Memory
+    from nmigen.compat.sim import run_simulation
+    from nmigen import Memory
 
     # Store some string in the memory, shifted left by 4 so each
     # character takes up 12 bits.

--- a/gateware/daqnet/user.py
+++ b/gateware/daqnet/user.py
@@ -1,8 +1,8 @@
-from nmigen import Module, Signal, Memory
+from nmigen import Module, Signal, Memory, Elaboratable
 from .utils import LFSR
 
 
-class User:
+class User(Elaboratable):
     def __init__(self):
         self.user_rx_mem = Memory(8, 32)
         self.user_tx_mem = Memory(8, 32,

--- a/gateware/daqnet/utils.py
+++ b/gateware/daqnet/utils.py
@@ -5,10 +5,10 @@ Copyright 2018-2019 Adam Greig
 Released under the MIT license; see LICENSE for details.
 """
 
-from nmigen import Module, Signal, Cat
+from nmigen import Module, Signal, Cat, Elaboratable
 
 
-class LFSR:
+class LFSR(Elaboratable):
     TAPS = {7: 6, 9: 5, 11: 9, 15: 14, 20: 3, 23: 18, 31: 28}
 
     def __init__(self, k):
@@ -33,7 +33,7 @@ class LFSR:
         return m
 
 
-class PulseStretch:
+class PulseStretch(Elaboratable):
     def __init__(self, nclks):
         # Inputs
         self.trigger = Signal()


### PR DESCRIPTION
This synthesizes, but placement of the design fails -- logic cell utilization is much larger than the target.  I'm not sure why this is occurring as the only changes are to address API changes in nmigen.  No behavior or other design changes were made.

```
yosys -q -p synth_ice40 -relut -json build/switch.json build/switch.il
nextpnr-ice40 --hx8k --package bg121 --json build/switch.json --pcf build/switch.pcf --asc build/switch.asc --seed 0 --freq 100
Info: Importing module switch
Info: Rule checker, verifying imported design
Info: Checksum: 0xaec7e431

Info: constrained 'clk25' to bel 'X16/Y33/io1'
Info: constrained 'rmii_txd0' to bel 'X4/Y0/io1'
Info: constrained 'rmii_txd1' to bel 'X4/Y0/io0'
Info: constrained 'rmii_txen' to bel 'X6/Y0/io1'
Info: constrained 'rmii_rxd0' to bel 'X15/Y0/io1'
Info: constrained 'rmii_rxd1' to bel 'X15/Y0/io0'
Info: constrained 'rmii_crs_dv' to bel 'X12/Y0/io0'
Info: constrained 'rmii_ref_clk' to bel 'X12/Y0/io1'
Info: constrained 'rmii_mdc' to bel 'X7/Y0/io1'
Info: constrained 'rmii_mdio' to bel 'X11/Y0/io1'
Info: constrained 'phy_rst' to bel 'X0/Y4/io1'
Info: constrained 'eth_led' to bel 'X0/Y4/io0'
Info: constrained 'user_led_1' to bel 'X31/Y33/io1'
Info: constrained 'user_led_2' to bel 'X30/Y33/io1'

Info: Packing constants..
Info: Packing IOs..
Info: rmii_mdio feeds SB_IO $techmap\mac.phy_manager.mdio.$1.io, removing $nextpnr_iobuf rmii_mdio.
Info: Packing LUT-FFs..
Info: Packing non-LUT FFs..
Info: Packing carries..
Info: Packing RAMs..
Info: Placing PLLs..
Info:   constrained PLL 'pll' to X16/Y33/pll_3
Info: Packing special functions..
Info: Promoting globals..
Info: promoting rmii_ref_clk (fanout 16676)
Info: promoting $abc$444569$auto$rtlil.cc:1942:NotGate$411637 [reset] (fanout 16428)
Info: promoting ipstack.udp_tx_done [reset] (fanout 17)
Info: promoting ipstack.eth.ipv4_done [reset] (fanout 17)
Info: promoting ipstack.eth.ipv4.icmpv4_done [reset] (fanout 17)
Info: promoting $abc$444569$auto$dff2dffe.cc:158:make_patterns_logic$373798 [cen] (fanout 96)
Info: promoting $abc$444569$auto$dff2dffe.cc:158:make_patterns_logic$362247 [cen] (fanout 32)
Info: Constraining chains...
Info: Checksum: 0x436715fe

Info: Annotating ports with timing budgets for target frequency 100.00 MHz
Info: Checksum: 0x305ca1e6

Info: Device utilisation:
Info: 	         ICESTORM_LC: 65998/ 7680   859%
Info: 	        ICESTORM_RAM:     6/   32    18%
Info: 	               SB_IO:    14/  256     5%
Info: 	               SB_GB:     8/    8   100%
Info: 	        ICESTORM_PLL:     1/    2    50%
Info: 	         SB_WARMBOOT:     0/    1     0%

Info: Placed 16 cells based on constraints.
Info: Creating initial placement for remaining 66011 cells.
Info:   initial placement placed 500/66011 cells
Info:   initial placement placed 1000/66011 cells
Info:   initial placement placed 1500/66011 cells
ERROR: failed to place cell '$auto$simplemap.cc:420:simplemap_dff$70425_DFFLC' of type 'ICESTORM_LC'
ERROR: Placing design failed.
```
Any ideas why the design is so much larger than the device?  I believe you said on Twitter that it used 1700 elements, here we're nearly 40 times that.

There are also a few `Elaboratable created but never used` errors occurring with this update:

- gateware/daqnet/ethernet/mdio.py", line 60
- gateware/daqnet/ethernet/mdio.py", line 66
- gateware/daqnet/ethernet/mac.py", line 116
- gateware/daqnet/ethernet/mac.py", line 118
- gateware/daqnet/ethernet/mac.py", line 121
- gateware/daqnet/ethernet/mac.py", line 122

Any suggestions on why these are being detected at not used?

Lastly, three tests fail on my machine (because I don't have migen installed, only nmigen).  They are:

- daqnet/sd_adc.py : test_cic : `AttributeError: 'CIC' object has no attribute 'sync'`
- daqnet/uart.py : test_uart_tx : `AttributeError: 'UARTTx' object has no attribute 'sync'`
- daqnet/uart.py : test_uart_tx_from_memory : `AttributeError: 'Memory' object has no attribute 'get_port'`